### PR TITLE
Fixed php.ini size detection.

### DIFF
--- a/resources/config/config.php
+++ b/resources/config/config.php
@@ -1,6 +1,7 @@
 <?php
 
 use Anomaly\FilesModule\Folder\Contract\FolderRepositoryInterface;
+use Anomaly\UploadFieldType\UploadFieldType;
 
 return [
     'folder' => [
@@ -22,15 +23,15 @@ return [
         'type'     => 'anomaly.field_type.integer',
         'required' => true,
         'config'   => [
-            'default_value' => function () {
-                $post = str_replace('M', '', ini_get('post_max_size'));
-                $file = str_replace('M', '', ini_get('upload_max_filesize'));
+            'default_value' => function (UploadFieldType $type) {
+                $post = $type->getSize('post_max_size');
+                $file = $type->getSize('upload_max_filesize');
 
                 return $file > $post ? $post : $file;
             },
-            'max'           => function () {
-                $post = str_replace('M', '', ini_get('post_max_size'));
-                $file = str_replace('M', '', ini_get('upload_max_filesize'));
+            'max'           => function (UploadFieldType $type) {
+                $post = $type->getSize('post_max_size');
+                $file = $type->getSize('upload_max_filesize');
 
                 return $file > $post ? $post : $file;
             },

--- a/src/UploadFieldType.php
+++ b/src/UploadFieldType.php
@@ -124,8 +124,8 @@ class UploadFieldType extends FieldType
     {
         $config = parent::getConfig();
 
-        $post = str_replace('M', '', ini_get('post_max_size'));
-        $file = str_replace('M', '', ini_get('upload_max_filesize'));
+        $post = $this->getSize('post_max_size') ;
+        $file = $this->getSize('upload_max_filesize');
 
         $server = $file > $post ? $post : $file;
 
@@ -201,5 +201,17 @@ class UploadFieldType extends FieldType
     public function getColumnName()
     {
         return parent::getColumnName() . '_id';
+    }
+
+    /**
+     * Get php.ini value and convert it to Mb if needed.
+     *
+     * @param $key
+     * @return float|int
+     */
+    public function getSize($key)
+    {
+        preg_match('/([0-9]*)(M|G)/im', ini_get($key), $matches);
+        return $matches[2] === 'G' ? 1024 * $matches[1] : $matches[1];
     }
 }

--- a/src/UploadFieldType.php
+++ b/src/UploadFieldType.php
@@ -211,7 +211,7 @@ class UploadFieldType extends FieldType
      */
     public function getSize($key)
     {
-        preg_match('/([0-9]*)(K|M|G)/im', ini_get($key), $matches);
+        preg_match('/([0-9]*)(K|M|G)?/im', ini_get($key), $matches);
         return $matches[2] === 'K' ? $matches[1] / 1024 : $matches[2] === 'G' ? $matches[1] * 1024 : $matches[1];
     }
 }

--- a/src/UploadFieldType.php
+++ b/src/UploadFieldType.php
@@ -211,7 +211,7 @@ class UploadFieldType extends FieldType
      */
     public function getSize($key)
     {
-        preg_match('/([0-9]*)(M|G)/im', ini_get($key), $matches);
-        return $matches[2] === 'G' ? 1024 * $matches[1] : $matches[1];
+        preg_match('/([0-9]*)(K|M|G)/im', ini_get($key), $matches);
+        return $matches[2] === 'K' ? $matches[1] / 1024 : $matches[2] === 'G' ? $matches[1] * 1024 : $matches[1];
     }
 }

--- a/src/UploadFieldType.php
+++ b/src/UploadFieldType.php
@@ -124,7 +124,7 @@ class UploadFieldType extends FieldType
     {
         $config = parent::getConfig();
 
-        $post = $this->getSize('post_max_size') ;
+        $post = $this->getSize('post_max_size');
         $file = $this->getSize('upload_max_filesize');
 
         $server = $file > $post ? $post : $file;
@@ -212,6 +212,6 @@ class UploadFieldType extends FieldType
     public function getSize($key)
     {
         preg_match('/([0-9]*)(K|M|G)?/im', ini_get($key), $matches);
-        return $matches[2] === 'K' ? $matches[1] / 1024 : $matches[2] === 'G' ? $matches[1] * 1024 : $matches[1];
+        return $matches[2] === 'G' ? $matches[1] * 1024 : $matches[1] === 'M' ? $matches[1] : $matches[2] === 'K' ? $matches[1] / 1024 : $matches[1] / (1024 * 1024);
     }
 }


### PR DESCRIPTION
Size detection assumed the only valid notation was xxxM, while xxxG, xxxK and even xxx are also valid.